### PR TITLE
Add admin user management server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pillow==10.0.1
 python-engineio==4.7.1
 eventlet==0.33.3
 
+
+openpyxl==3.1.2

--- a/server.py
+++ b/server.py
@@ -1,0 +1,202 @@
+# User management server for Huiying Proxy
+
+import os
+import json
+from datetime import datetime
+from functools import wraps
+
+from flask import Flask, render_template, request, redirect, url_for, session, send_file
+from werkzeug.utils import secure_filename
+
+from openpyxl import Workbook, load_workbook
+
+USERS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'users.json')
+app = Flask(__name__)
+app.secret_key = os.environ.get('SECRET_KEY', 'huiying-secret')
+
+
+def load_users() -> dict:
+    if os.path.exists(USERS_FILE):
+        with open(USERS_FILE, 'r', encoding='utf-8') as f:
+            try:
+                return json.load(f).get('users', {})
+            except Exception:
+                return {}
+    return {}
+
+
+def save_users(users: dict) -> None:
+    with open(USERS_FILE, 'w', encoding='utf-8') as f:
+        json.dump({'users': users}, f, indent=4, ensure_ascii=False)
+
+
+def admin_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if session.get('admin') != 'horsray':
+            return redirect(url_for('login'))
+        return f(*args, **kwargs)
+    return wrapper
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        users = load_users()
+        user = users.get(username)
+        if user and user.get('password') == password and user.get('is_admin'):
+            session['admin'] = username
+            user['last_login'] = datetime.now().isoformat()
+            users[username] = user
+            save_users(users)
+            return redirect(url_for('user_list'))
+        return render_template('login.html', error='登录失败')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.pop('admin', None)
+    return redirect(url_for('login'))
+
+
+@app.route('/')
+@admin_required
+def index():
+    return redirect(url_for('user_list'))
+
+
+@app.route('/users')
+@admin_required
+def user_list():
+    users = load_users()
+    return render_template('users.html', users=users)
+
+
+@app.route('/users/add', methods=['POST'])
+@admin_required
+def add_user():
+    username = request.form.get('username')
+    password = request.form.get('password')
+    is_admin = bool(request.form.get('is_admin'))
+    if not username or not password:
+        return redirect(url_for('user_list'))
+    users = load_users()
+    if username in users:
+        return redirect(url_for('user_list'))
+    users[username] = {
+        'password': password,
+        'is_admin': is_admin,
+        'created_at': datetime.now().isoformat(),
+        'last_login': None
+    }
+    save_users(users)
+    return redirect(url_for('user_list'))
+
+
+@app.route('/users/<name>/delete', methods=['POST'])
+@admin_required
+def delete_user(name):
+    users = load_users()
+    if name in users:
+        users.pop(name)
+        save_users(users)
+    return redirect(url_for('user_list'))
+
+
+@app.route('/users/<name>/update', methods=['POST'])
+@admin_required
+def update_user(name):
+    new_name = request.form.get('username')
+    password = request.form.get('password')
+    is_admin = bool(request.form.get('is_admin'))
+    users = load_users()
+    if name in users:
+        user = users[name]
+        if new_name and new_name != name:
+            users[new_name] = user
+            users.pop(name)
+            name = new_name
+        if password:
+            users[name]['password'] = password
+        users[name]['is_admin'] = is_admin
+        save_users(users)
+    return redirect(url_for('user_list'))
+
+
+@app.route('/users/import', methods=['POST'])
+@admin_required
+def import_users():
+    file = request.files.get('file')
+    if not file:
+        return redirect(url_for('user_list'))
+    filename = secure_filename(file.filename)
+    if not filename:
+        return redirect(url_for('user_list'))
+    wb = load_workbook(file)
+    ws = wb.active
+    users = load_users()
+    first = True
+    for row in ws.iter_rows(values_only=True):
+        if first:
+            first = False
+            continue
+        username = str(row[0]) if row and row[0] else None
+        password = str(row[1]) if row and len(row) > 1 else None
+        is_admin = bool(row[2]) if row and len(row) > 2 else False
+        if username and password:
+            users[username] = {
+                'password': password,
+                'is_admin': is_admin,
+                'created_at': datetime.now().isoformat(),
+                'last_login': None
+            }
+    save_users(users)
+    return redirect(url_for('user_list'))
+
+
+@app.route('/users/export')
+@admin_required
+def export_users():
+    users = load_users()
+    wb = Workbook()
+    ws = wb.active
+    ws.append(['username', 'password', 'is_admin', 'created_at', 'last_login'])
+    for name, info in users.items():
+        ws.append([
+            name,
+            info.get('password'),
+            info.get('is_admin'),
+            info.get('created_at'),
+            info.get('last_login'),
+        ])
+    path = 'users_export.xlsx'
+    wb.save(path)
+    return send_file(path, as_attachment=True)
+
+
+@app.route('/users/bulk_create', methods=['POST'])
+@admin_required
+def bulk_create():
+    count = int(request.form.get('count', 0))
+    users = load_users()
+    for _ in range(count):
+        while True:
+            uname = f"huiying{os.urandom(4).hex()}"[:12]
+            if uname not in users:
+                break
+        pwd = os.urandom(4).hex()
+        users[uname] = {
+            'password': pwd,
+            'is_admin': False,
+            'created_at': datetime.now().isoformat(),
+            'last_login': None
+        }
+    save_users(users)
+    return redirect(url_for('user_list'))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5001, debug=False)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}用户管理{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <span class="navbar-brand">用户管理系统</span>
+    <span class="navbar-text">
+      <a class="text-light" href="{{ url_for('logout') }}">退出</a>
+    </span>
+  </div>
+</nav>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-2">
+      <ul class="list-group">
+        <li class="list-group-item"><a href="{{ url_for('user_list') }}">用户列表</a></li>
+      </ul>
+    </div>
+    <div class="col-10">
+      {% block content %}{% endblock %}
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>管理员登录</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex justify-content-center align-items-center vh-100">
+<div class="card p-4" style="min-width:320px;">
+  <h5 class="card-title mb-3">管理员登录</h5>
+  {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+  <form method="post">
+    <div class="mb-3">
+      <label class="form-label">用户名</label>
+      <input type="text" name="username" class="form-control" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">密码</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">登录</button>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,78 @@
+{% extends 'layout.html' %}
+{% block title %}用户列表{% endblock %}
+{% block content %}
+<h3>新增用户</h3>
+<form class="row g-3" action="{{ url_for('add_user') }}" method="post">
+  <div class="col-md-3">
+    <input type="text" name="username" class="form-control" placeholder="用户名" required>
+  </div>
+  <div class="col-md-3">
+    <input type="text" name="password" class="form-control" placeholder="密码" required>
+  </div>
+  <div class="col-md-2 form-check mt-2">
+    <input class="form-check-input" type="checkbox" name="is_admin" id="is_admin">
+    <label class="form-check-label" for="is_admin">管理员</label>
+  </div>
+  <div class="col-md-2">
+    <button type="submit" class="btn btn-success">新增</button>
+  </div>
+</form>
+<hr>
+<h3>批量开通随机账号</h3>
+<form class="row g-3" action="{{ url_for('bulk_create') }}" method="post">
+  <div class="col-md-2">
+    <input type="number" name="count" class="form-control" min="1" value="1">
+  </div>
+  <div class="col-md-2">
+    <button type="submit" class="btn btn-primary">开通</button>
+  </div>
+</form>
+<hr>
+<h3>批量导入/导出</h3>
+<form class="row g-3" action="{{ url_for('import_users') }}" method="post" enctype="multipart/form-data">
+  <div class="col-md-4">
+    <input type="file" name="file" class="form-control" required>
+  </div>
+  <div class="col-md-2">
+    <button type="submit" class="btn btn-secondary">导入</button>
+  </div>
+  <div class="col-md-2">
+    <a class="btn btn-outline-secondary" href="{{ url_for('export_users') }}">导出</a>
+  </div>
+</form>
+<hr>
+<h3>用户列表</h3>
+<table class="table table-striped">
+<thead>
+  <tr>
+    <th>用户名</th>
+    <th>权限</th>
+    <th>创建时间</th>
+    <th>最后登录</th>
+    <th>修改</th>
+    <th>删除</th>
+  </tr>
+</thead>
+<tbody>
+{% for name, info in users.items() %}
+<tr>
+  <form action="{{ url_for('update_user', name=name) }}" method="post">
+    <td><input name="username" class="form-control" value="{{ name }}"></td>
+    <td><input type="checkbox" name="is_admin" {% if info.is_admin %}checked{% endif %}></td>
+    <td>{{ info.created_at }}</td>
+    <td>{{ info.last_login or '' }}</td>
+    <td>
+      <input type="text" name="password" class="form-control" placeholder="新密码">
+    </td>
+    <td class="d-flex">
+      <button type="submit" class="btn btn-sm btn-primary me-2">修改</button>
+  </form>
+      <form action="{{ url_for('delete_user', name=name) }}" method="post" onsubmit="return confirm('确定删除?')">
+        <button type="submit" class="btn btn-sm btn-danger">删除</button>
+      </form>
+    </td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}

--- a/users.json
+++ b/users.json
@@ -1,7 +1,10 @@
 {
     "users": {
         "horsray": {
-            "password": "zzy83007932"
+            "password": "zzy83007932",
+            "is_admin": true,
+            "created_at": "2025-07-24T14:12:25.809815",
+            "last_login": null
         }
     }
 }


### PR DESCRIPTION
## Summary
- revert main.py to original proxy logic
- add `server.py` with standalone admin management features
- create Bootstrap templates for admin login and user management
- remove old minimal templates

## Testing
- `python -m py_compile main.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68823ec8c3108332ad5e934b2c811f0d