### PR TITLE
Switch user storage to SQLite and add session persistence

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,47 @@
+import os
+import sqlite3
+import json
+from threading import Lock
+
+DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'users.db')
+
+db_lock = Lock()
+
+
+def init_db():
+    """Initialize the SQLite database and create table if not exists."""
+    with db_lock, sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, data TEXT)'
+        )
+        conn.commit()
+
+
+def load_users() -> dict:
+    """Load all users from the SQLite database as a dictionary."""
+    init_db()
+    with db_lock, sqlite3.connect(DB_PATH) as conn:
+        cursor = conn.execute('SELECT username, data FROM users')
+        users = {}
+        for username, data in cursor.fetchall():
+            try:
+                users[username] = json.loads(data)
+            except Exception:
+                users[username] = {}
+        return users
+
+
+def save_users(users: dict) -> None:
+    """Persist the provided users dictionary to the SQLite database."""
+    init_db()
+    with db_lock, sqlite3.connect(DB_PATH) as conn:
+        existing = {row[0] for row in conn.execute('SELECT username FROM users')}
+        for username, info in users.items():
+            conn.execute(
+                'REPLACE INTO users (username, data) VALUES (?, ?)',
+                (username, json.dumps(info, ensure_ascii=False))
+            )
+            existing.discard(username)
+        for username in existing:
+            conn.execute('DELETE FROM users WHERE username = ?', (username,))
+        conn.commit()


### PR DESCRIPTION
## Summary
- migrate `users.json` to an SQLite backed database with concurrency lock
- update `main.py` and `server.py` to read/write users via the new DB
- persist active sessions in `sessions.json` for recovery after restart

## Testing
- `python -m py_compile db_utils.py main.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68873b7ce994833296f39246d4b3337b